### PR TITLE
Show book stats #19

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -22,4 +22,12 @@ class Book < ApplicationRecord
   def remove_author(author)
     authors.where.not(id: author.id)
   end
+
+  def grab_reviews(direction, limit)
+    if direction == "top"
+      self.reviews.order(rating: :desc, username: :desc).limit(limit)
+    elsif direction == "bottom"
+      self.reviews.order(rating: :asc, username: :desc).limit(limit)
+    end
+  end
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,6 +1,7 @@
 <section class="book-information">
   <img src="<%= @book.thumbnail %>" alt="cover of <%= @book.title %>">
   <p>Title: <%= @book.title %> </p>
+  <p class="average-rating">Rating: <%= @book.average_rating %></p>
   <p>Page Count: <%= @book.pages %> </p>
   <p>Year Published: <%= @book.year_published %> </p>
   <p>Author(s):</p>
@@ -9,6 +10,19 @@
     <li><%= link_to author.name %></li>
   <% end %>
   </ul>
+  <section class="book-stats">
+    <section class="top-reviews">
+      <%= @book.grab_reviews('top', 3).each do |review| %>
+        <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
+      <% end %>
+    </section>
+
+    <section class="bottom-reviews">
+      <%= @book.grab_reviews('bottom', 3).each do |review| %>
+        <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
+      <% end %>
+    </section>
+  </section>
 </section>
 
 <section class="reviews">

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -11,15 +11,21 @@
   <% end %>
   </ul>
   <section class="book-stats">
-    <section class="top-reviews">
-      <%= @book.grab_reviews('top', 3).each do |review| %>
-        <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
-      <% end %>
-    </section>
+    <% unless @book.reviews.empty? %>
+      <section class="top-reviews">
+        <p>Top Reviews</p>
+        <%= @book.grab_reviews('top', 3).each do |review| %>
+          <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
+        <% end %>
+      </section>
 
-    <section class="bottom-reviews">
-      <%= @book.grab_reviews('bottom', 3).each do |review| %>
-        <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
+      <section class="bottom-reviews">
+        <p>Bottome Reviews</p>
+        <%= @book.grab_reviews('bottom', 3).each do |review| %>
+          <p>Title: <%= review.title %>, Rating: <%= review.rating %>, User: <%= link_to review.username %></p>
+        <% end %>
+      <% else %>
+        <%= link_to "Be the first to review this book"  %>
       <% end %>
     </section>
   </section>

--- a/spec/features/book_show_spec.rb
+++ b/spec/features/book_show_spec.rb
@@ -51,4 +51,64 @@ RSpec.describe 'Book Show Page', type: :feature do
       expect(page).to have_content("This book was bad.")
     end
   end
+
+  describe 'Book show page statistics' do
+    it 'shows top and bottom three reviews for a book' do
+      author = Author.create(name: 'bob')
+      book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+      book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
+      book.reviews.create(rating: 4, title: "haha", description: "whahhednd vijnvsihb", username: "rob")
+      book.reviews.create(rating: 3, title: "whatever", description: "whahhednd vijnvsihb", username: "harbi")
+      book.reviews.create(rating: 2, title: "is horrible", description: "whahhednd vijnvsihb", username: "stub")
+      book.reviews.create(rating: 1, title: "super bad", description: "whahhednd vijnvsihb", username: "rude")
+
+      visit book_path(book)
+
+      within '.average-rating' do
+        expect(page).to have_content("Rating: 3")
+      end
+
+      within '.book-stats' do
+        within '.top-reviews' do
+          expect(page).to have_content("Title: meh")
+          expect(page).to have_content("Rating: 5")
+          expect(page).to have_content("User: bob")
+          expect(page).to have_link("bob")
+
+          expect(page).to have_content("Title: haha")
+          expect(page).to have_content("Rating: 4")
+          expect(page).to have_content("User: rob")
+          expect(page).to have_link("rob")
+
+          expect(page).to have_content("Title: whatever")
+          expect(page).to have_content("Rating: 3")
+          expect(page).to have_content("User: harbi")
+          expect(page).to have_link("harbi")
+
+          expect(page).to_not have_content("is horrible")
+          expect(page).to_not have_content("super bad")
+        end
+
+        within '.bottom-reviews' do
+          expect(page).to have_content("super bad")
+          expect(page).to have_content("Rating: 1")
+          expect(page).to have_content("User: rude")
+          expect(page).to have_link("rude")
+
+          expect(page).to have_content("is horrible")
+          expect(page).to have_content("Rating: 2")
+          expect(page).to have_content("User: stub")
+          expect(page).to have_link("stub")
+
+          expect(page).to have_content("whatever")
+          expect(page).to have_content("Rating: 3")
+          expect(page).to have_content("User: harbi")
+          expect(page).to have_link("harbi")
+
+          expect(page).to_not have_content("haha")
+          expect(page).to_not have_content("meh")
+        end
+      end
+    end
+  end
 end

--- a/spec/features/book_show_spec.rb
+++ b/spec/features/book_show_spec.rb
@@ -110,5 +110,52 @@ RSpec.describe 'Book Show Page', type: :feature do
         end
       end
     end
+    it 'Shows a message when no reviews are present' do
+      author = Author.create(name: 'bob')
+      book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+
+      visit book_path(book)
+      
+      expect(page).to_not have_content("Top Reviews")
+      expect(page).to_not have_content("Bottom Reviews")
+      expect(page).to have_link("Be the first to review this book")
+    end
+
+    it 'is able to show less than three reviews' do
+      author = Author.create(name: 'bob')
+      book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+      book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
+      book.reviews.create(rating: 4, title: "haha", description: "whahhednd vijnvsihb", username: "rob")
+
+      visit book_path(book)
+
+      within '.book-stats' do
+        within '.top-reviews' do
+          expect(page).to have_content("Title: meh")
+          expect(page).to have_content("Rating: 5")
+          expect(page).to have_content("User: bob")
+          expect(page).to have_link("bob")
+
+          expect(page).to have_content("Title: haha")
+          expect(page).to have_content("Rating: 4")
+          expect(page).to have_content("User: rob")
+          expect(page).to have_link("rob")
+        end
+      end
+
+      within '.book-stats' do
+        within '.bottom-reviews' do
+          expect(page).to have_content("Title: haha")
+          expect(page).to have_content("Rating: 4")
+          expect(page).to have_content("User: rob")
+          expect(page).to have_link("rob")
+
+          expect(page).to have_content("Title: meh")
+          expect(page).to have_content("Rating: 5")
+          expect(page).to have_content("User: bob")
+          expect(page).to have_link("bob")
+        end
+      end
+    end
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -51,5 +51,23 @@ RSpec.describe Book, type: :model do
         expect(expectation).to eq(result)
       end
     end
+
+    describe '.grab_reviews' do
+      it 'returns the top or bottom three reviews for a book' do
+        author = Author.create(name: 'bob')
+        book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+        review_5 = book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
+        review_4 = book.reviews.create(rating: 4, title: "haha", description: "whahhednd vijnvsihb", username: "rob")
+        review_3 = book.reviews.create(rating: 3, title: "whatever", description: "whahhednd vijnvsihb", username: "harbi")
+        review_2 = book.reviews.create(rating: 2, title: "is horrible", description: "whahhednd vijnvsihb", username: "stub")
+        review_1 = book.reviews.create(rating: 1, title: "super bad", description: "whahhednd vijnvsihb", username: "rude")
+
+        result_top = [review_5, review_4, review_3]
+        result_bottom = [review_1, review_2, review_3]
+
+        expect(book.grab_reviews('desc')).to eq(result_top)
+        expect(book.grab_reviews('asc')).to eq(result_bottom)
+      end
+    end
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Book, type: :model do
     end
 
     describe '.grab_reviews' do
-      it 'returns the top or bottom three reviews for a book' do
+      it 'returns the top or bottom number of reviews for a book' do
         author = Author.create(name: 'bob')
         book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
         review_5 = book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
@@ -65,8 +65,8 @@ RSpec.describe Book, type: :model do
         result_top = [review_5, review_4, review_3]
         result_bottom = [review_1, review_2, review_3]
 
-        expect(book.grab_reviews('desc')).to eq(result_top)
-        expect(book.grab_reviews('asc')).to eq(result_bottom)
+        expect(book.grab_reviews('top', 3)).to eq(result_top)
+        expect(book.grab_reviews('bottom', 3)).to eq(result_bottom)
       end
     end
   end


### PR DESCRIPTION
Adds statistics to the book show page.

The show page will not display the average rating as well as the top and bottom three reviews of the book.

Method added to model was made to be flexible so it could handle multiple both top and bottom as well as limit by any amount.

All tests passing. Coverage at 100%

closes #19