### PR TITLE
Book titles are links to book show page #29

### DIFF
--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -4,7 +4,7 @@
 
 <% @books.each do |book| %>
   <section id="book-<%= book.id %>">
-    <img src="<%= book.thumbnail %>" alt="Cover of <%= book.title %>">
+    <a href=<%= book_path(book) %>><img src="<%= book.thumbnail %>" alt="Cover of <%= book.title %>"></a>
     <p>Title: <%= link_to book.title, book_path(book) %></p>
     <p>Page Count: <%= book.pages %></p>
     <p>Year Published: <%= book.year_published %></p>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -3,7 +3,7 @@
 </section>
 <% @books.each do |book| %>
   <section id="book-<%= book.id %>">
-    <img src="<%= book.thumbnail %>" alt="cover of <%= book.title %>">
+    <a href=<%= book_path(book) %>><img src="<%= book.thumbnail %>" alt="cover of <%= book.title %>"></a>
     <p>Title: <%= link_to book.title, book_path(book) %> </p>
     <p>Page Count: <%= book.pages %> </p>
     <p>Year Published: <%= book.year_published %> </p>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -4,7 +4,7 @@
 <% @books.each do |book| %>
   <section id="book-<%= book.id %>">
     <img src="<%= book.thumbnail %>" alt="cover of <%= book.title %>">
-    <p>Title: <%= book.title %> </p>
+    <p>Title: <%= link_to book.title, book_path(book) %> </p>
     <p>Page Count: <%= book.pages %> </p>
     <p>Year Published: <%= book.year_published %> </p>
     <p>Author(s):</p>

--- a/spec/features/author_show_spec.rb
+++ b/spec/features/author_show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'As a visitor', type: :feature do
     within "#book-#{book_1.id}" do
       expect(page).to have_xpath("//img[@src='steve.jpg']")
       expect(page).to have_content("Title: #{book_1.title}")
-      expect(page).to have_link("#{book_1.title}")
+      expect(page).to have_link(book_1.title, href: book_path(book_1))
       expect(page).to have_content("Page Count: #{book_1.pages}")
       expect(page).to have_content("Year Published: #{book_1.year_published}")
       expect(page).to_not have_link("Bob")
@@ -24,7 +24,7 @@ RSpec.describe 'As a visitor', type: :feature do
     within "#book-#{book_2.id}" do
       expect(page).to have_xpath("//img[@src='steve.jpg']")
       expect(page).to have_content("Title: #{book_2.title}")
-      expect(page).to have_link("#{book_2.title}")
+      expect(page).to have_link(book_2.title, href: book_path(book_2))
       expect(page).to have_content("Page Count: #{book_2.pages}")
       expect(page).to have_content("Year Published: #{book_2.year_published}")
       expect(page).to_not have_link("Bob")

--- a/spec/features/book_index_spec.rb
+++ b/spec/features/book_index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Book index', type: :feature do
 
     within "#book-#{book_1.id}" do
       expect(page).to have_xpath("//img[@src='steve.jpg']")
-      expect(page).to have_content("Title: where the wild things are")
+      expect(page).to have_link("where the wild things are", href: book_path(book_1))
       expect(page).to have_content("Page Count: #{book_1.pages}")
       expect(page).to have_content("Year Published: 1987")
       expect(page).to have_link(author.name)
@@ -20,7 +20,7 @@ RSpec.describe 'Book index', type: :feature do
 
     within "#book-#{book_2.id}" do
       expect(page).to have_xpath("//img[@src='bob.jpg']")
-      expect(page).to have_content("Title: Whatever")
+      expect(page).to have_link("Whatever", href: book_path(book_2))
       expect(page).to have_content("Page Count: 230")
       expect(page).to have_content("Year Published: 2019")
       expect(page).to have_link("bob")
@@ -28,7 +28,7 @@ RSpec.describe 'Book index', type: :feature do
 
     within "#book-#{book_3.id}" do
       expect(page).to have_xpath("//img[@src='andrew.jpg']")
-      expect(page).to have_content("Title: meh")
+      expect(page).to have_link("meh", href: book_path(book_3))
       expect(page).to have_content("Page Count: 456")
       expect(page).to have_content("Year Published: 1978")
       expect(page).to have_link("bob")


### PR DESCRIPTION
Added links to all book titles and thumbnails. Clicking these links now redirects to the book show page.

The thumbnails was not a requirement for the user story but it made sense to add it for user experience.  I just used a `<a href=''></a>` tag for the thumbnails.  I attempted using a link_to with an image_tag but it was breaking a lot of our tests that use mock urls.  This approach kept our current tests passing.

Passes all RSpec tests with 100% SimpleCov coverage, including running the model specs independently.

Closes #29 