### PR TITLE
Author show top review #13

### DIFF
--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -16,5 +16,13 @@
         <% end %>
       </ul>
       <% end %>
+    <p>Top Review:</p>
+    <%book.grab_reviews("top", 1).each do |review| %>
+    <ul>
+      <li>Title: <%= review.title %></li>
+      <li>Rating: <%= review.rating %> out of 5</li>
+      <li>User: <%= link_to review.username%> <%#, user_index_path(review.username) %>  </li>
+    </ul>
+    <% end %>
   </section>
 <% end %>

--- a/spec/features/author_show_spec.rb
+++ b/spec/features/author_show_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe 'As a visitor to an author show page', type: :feature do
     book.reviews.create(rating: 4, title: "haha", description: "whahhednd vijnvsihb", username: "rob")
     book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
 
+    book_2 = author.books.create(thumbnail: 'steve.jpg', title: 'Whatever the whatever', pages: 40, year_published: 1987)
+    book_2.reviews.create(rating: 3, title: "hammy", description: "whahhednd vijnvsihb", username: "harbi")
+
     visit author_path(author)
 
     within "#book-#{book.id}" do
@@ -94,6 +97,13 @@ RSpec.describe 'As a visitor to an author show page', type: :feature do
       expect(page).to have_content("User: bob")
       expect(page).to have_link("bob")
       click_link 'bob'
+    end
+    within "#book-#{book_2.id}" do
+      expect(page).to have_content("Top Review:")
+      expect(page).to have_content("Rating: 3 out of 5")
+      expect(page).to have_content("Title: hammy")
+      expect(page).to have_content("User: harbi")
+      expect(page).to have_link("harbi")
     end
 
     # expect(current_path).to eq(user_index_path) Renable when merged

--- a/spec/features/author_show_spec.rb
+++ b/spec/features/author_show_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe 'As a visitor to an author show page', type: :feature do
       expect(page).to have_content("Title: meh")
       expect(page).to have_content("User: bob")
       expect(page).to have_link("bob")
-      click_link 'bob'
     end
     within "#book-#{book_2.id}" do
       expect(page).to have_content("Top Review:")
@@ -105,7 +104,8 @@ RSpec.describe 'As a visitor to an author show page', type: :feature do
       expect(page).to have_content("User: harbi")
       expect(page).to have_link("harbi")
     end
-
-    # expect(current_path).to eq(user_index_path) Renable when merged
+    
+    click_link 'bob'
+    # expect(current_path).to eq(user_index_path("bob")) Renable when merged
   end
 end

--- a/spec/features/author_show_spec.rb
+++ b/spec/features/author_show_spec.rb
@@ -75,4 +75,27 @@ RSpec.describe 'As a visitor to an author show page', type: :feature do
       expect(page).to have_link("Steve", href: author_path(author_3))
     end
   end
+
+  it 'shows the top review information for each book on the page' do
+    author = Author.create(name: 'bob')
+    book = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+    book.reviews.create(rating: 3, title: "whatever", description: "whahhednd vijnvsihb", username: "harbi")
+    book.reviews.create(rating: 2, title: "is horrible", description: "whahhednd vijnvsihb", username: "stub")
+    book.reviews.create(rating: 1, title: "super bad", description: "whahhednd vijnvsihb", username: "rude")
+    book.reviews.create(rating: 4, title: "haha", description: "whahhednd vijnvsihb", username: "rob")
+    book.reviews.create(rating: 5, title: "meh", description: "whahhednd vijnvsihb", username: "bob")
+
+    visit author_path(author)
+
+    within "#book-#{book.id}" do
+      expect(page).to have_content("Top Review:")
+      expect(page).to have_content("Rating: 5 out of 5")
+      expect(page).to have_content("Title: meh")
+      expect(page).to have_content("User: bob")
+      expect(page).to have_link("bob")
+      click_link 'bob'
+    end
+
+    # expect(current_path).to eq(user_index_path) Renable when merged
+  end
 end


### PR DESCRIPTION
Adds top reviews to author show page.

It will successfully add info about the top review for each book on the author's show page
preemptively added the link to the user show page and expect in the test, they will need to be uncommented when merged as the test crashed when set without appropriate routing.

All tests passing otherwise

closes #13 