### PR TITLE
Fix broken links to users on the books/index page

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -15,4 +15,8 @@ class Review < ApplicationRecord
     .order('review_count desc, reviews.username desc')
     .limit(3)
   end
+
+  def self.find_review(user_name)
+    where(username: user_name).first
+  end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -21,7 +21,7 @@
     <h3>Most active users</h3>
     <ul>
       <% @reviews.most_active_users.each do |user| %>
-        <li><%= link_to user.username, user_path(user) %> (<%= user.review_count %>)</li>
+        <li><%= link_to user.username, user_path(@reviews.find_review(user.username)) %> (<%= user.review_count %>)</li>
       <% end %>
     </ul>
   </section>

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -47,5 +47,13 @@ RSpec.describe Review, type: :model do
         expect(active_users[2].review_count).to eq(2)
       end
     end
+    describe '.find_review' do
+      it 'returns the first review by a username' do
+        book_1 = Book.create(thumbnail: 'steve.jpg', title: 'Book 1 title', pages: 40, year_published: 1987)
+        review_1 = book_1.reviews.create(rating: 1, title: 'Review_title', description: 'Review_description', username: 'User1')
+
+        expect(Review.find_review(review_1.username)).to eq(review_1)
+      end
+    end
   end
 end


### PR DESCRIPTION
The "user" block variable from the .most_active_users is not truly a user.  It's a group_by with only username -> review_count.  Since the User show page requires a review.id, I wrote this Class method to find one if you only have the username.  The links are all now working properly.

RSpec all tests passing at 100% coverage.

Thought I could close user story 5 but realized there are more user links elsewhere. 