### PR TITLE
Delete a book review #8

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -22,6 +22,21 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def destroy
+    review = Review.find(params[:id])
+    book = review.book
+    user = review.username
+    review.destroy
+
+    other_user_review = Review.find_review(user)
+
+    if other_user_review
+      redirect_to(user_path(other_user_review))
+    else
+      redirect_to(books_path)
+    end
+  end
+
   private
 
   def review_params

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -8,5 +8,6 @@
   <p>Description: <%= review.description %></p>
   <p>Rating: <%= review.rating %> out of 5</p>
   <p>Date Reviewed: <%= review.created_at.strftime("%m/%d/%Y") %></p>
+  <%= link_to "Delete Review", review_path, method: :delete %>
 </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   resources :authors, only: [:show]
 
   resources :reviews, only: [:show], as: 'user'
+  resources :reviews, only: [:destroy]
 end

--- a/spec/features/delete_review_spec.rb
+++ b/spec/features/delete_review_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe "Delete a Review", type: :feature do
+  context 'as a visitor to a users show page' do
+    before :each do
+      author = Author.create(name: 'bob')
+      book_1 = author.books.create(thumbnail: 'steve.jpg', title: 'where the wild things are', pages: 40, year_published: 1987)
+      book_2 = author.books.create(thumbnail: 'steve.jpg', title: 'Book 2', pages: 40, year_published: 1987)
+      @review_1 = book_1.reviews.create(rating: 5, title: "Review 1 title", description: "Review 1 description", username: "User1")
+      @review_2 = book_2.reviews.create(rating: 3, title: "Review 2 title", description: "Review 2 description", username: "User1")
+
+      visit user_path(@review_1)
+    end
+
+    it 'shows a link next to each review to delete the review' do
+      within "#review-#{@review_1.id}" do
+        expect(page).to have_link("Delete Review")
+      end
+    end
+
+    it 'when I click delete, it returns me to a user show page' do
+      within "#review-#{@review_1.id}" do
+        click_on "Delete Review"
+      end
+
+      expect(current_path).to eq(user_path(@review_2))
+    end
+
+    it 'when I delete the last review for a user, it returns me to the books index page' do
+      within "#review-#{@review_1.id}" do
+        click_on "Delete Review"
+      end
+
+      within "#review-#{@review_2.id}" do
+        click_on "Delete Review"
+      end
+
+      expect(current_path).to eq(books_path)
+    end
+
+    it 'when I delete a review, it no longer shows on the page' do
+      expect(page).to have_content("Review 1 title")
+
+      within "#review-#{@review_1.id}" do
+        click_on "Delete Review"
+      end
+
+      expect(page).not_to have_content("Review 1 title")
+    end
+  end
+end


### PR DESCRIPTION
Added functionality to delete reviews from the Reviews(user) show page.  I setup the controller to redirect to the /books index page in the event that there are no more reviews remaining for that username.

Passing all tests with 100% coverage.

Closes #8 