### PR TITLE
Deleteing author from db #6

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -3,4 +3,14 @@ class AuthorsController < ApplicationController
     @author = Author.find(params[:id])
     @books = @author.books
   end
+
+  def destroy
+    author = Author.find(params[:id])
+    books = author.books
+    books.each do |book|
+      book.destroy
+    end
+    author.destroy
+    redirect_to books_path
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -31,7 +31,6 @@ class BooksController < ApplicationController
     book = Book.find(params[:id])
     book.destroy
     redirect_to books_path
-
   end
 
   private

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,5 @@
 class Author < ApplicationRecord
-  has_many :book_authors
+  has_many :book_authors, dependent: :destroy
   has_many :books, through: :book_authors
 
   validates :name, uniqueness: true, presence: true

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,5 +1,6 @@
 <section class="author-name">
   <p><%= @author.name %></p>
+  <%= link_to "Delete Author", author_path(@author), method: :delete %>
 </section>
 
 <% @books.each do |book| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :books, only: [:index, :show, :new, :create, :destroy] do
     resources :reviews, only: [:new, :create]
   end
-  resources :authors, only: [:show]
+  resources :authors, only: [:show, :destroy]
 
   resources :reviews, only: [:show], as: 'user'
   resources :reviews, only: [:destroy]

--- a/spec/features/deleting_author_spec.rb
+++ b/spec/features/deleting_author_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'user clicks delete author link', type: :feature do
     click_link 'Delete Author'
 
     expect(current_path).to eq(books_path)
-    
+
     expect(page).to_not have_content(author_1.name)
     expect(page).to_not have_content(book_2.title)
     expect(page).to_not have_content(book_1.title)

--- a/spec/features/deleting_author_spec.rb
+++ b/spec/features/deleting_author_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'user clicks delete author link', type: :feature do
+  it 'allows a user to delete an author and associated books' do
+    author_1 = Author.create(name: 'bob')
+    author_2 = Author.create(name: 'andrew')
+    book_1 = author_1.books.create(thumbnail: 'steve.jpg', title: 'Book 1', pages: 40, year_published: 1987)
+    book_2 = Book.create!(thumbnail: 'steve.jpg', title: 'Book 2', pages: 40, year_published: 1987, authors: [author_1, author_2])
+    book_3 = author_2.books.create!(thumbnail: 'steve.jpg', title: 'Book 3', pages: 40, year_published: 1987)
+
+    visit author_path(author_1)
+
+    expect(page).to have_link("Delete Author")
+    expect(author_2.books.count).to eq(2)
+
+    click_link 'Delete Author'
+
+    expect(current_path).to eq(books_path)
+    
+    expect(page).to_not have_content(author_1.name)
+    expect(page).to_not have_content(book_2.title)
+    expect(page).to_not have_content(book_1.title)
+    expect(page).to have_content(author_2.name)
+    expect(page).to have_content(book_3.title)
+  end
+end


### PR DESCRIPTION
Implements and tests the delete action for authors.

users can now delete an author and remove all associated books. If they have co-authored a book that book will be deleted but the other author will remain untouched.

This also deleted all reviews.

closes #6 